### PR TITLE
[codex] Add content-level device key ban proof

### DIFF
--- a/Content.Client/_RuMC14/DeviceKey/DeviceKeySystem.cs
+++ b/Content.Client/_RuMC14/DeviceKey/DeviceKeySystem.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using Content.Shared._RuMC14.DeviceKey;
+using Robust.Shared.ContentPack;
+using Robust.Shared.IoC;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Client._RuMC14.DeviceKey;
+
+public sealed partial class DeviceKeySystem : EntitySystem
+{
+    [Dependency] private IResourceManager _resource = default!;
+    [Dependency] private ISharedPlayerManager _player = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    private static readonly ResPath DeviceKeyPath = new("/device_key");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<DeviceKeyChallengeEvent>(OnDeviceKeyChallenge);
+    }
+
+    private void OnDeviceKeyChallenge(DeviceKeyChallengeEvent msg)
+    {
+        var secret = LoadOrCreateSecret();
+        var deviceId = DeviceKeyProofHelpers.GetDeviceId(secret);
+        var proof = DeviceKeyProofHelpers.MakeProof(secret, msg.Challenge, _player.LocalUser!.Value.UserId);
+
+        RaiseNetworkEvent(new DeviceKeyProofEvent(msg.Challenge, deviceId, secret, proof));
+    }
+
+    private byte[] LoadOrCreateSecret()
+    {
+        var secret = TryReadSecret();
+        if (secret != null)
+            return secret;
+
+        secret = new byte[DeviceKeyProofHelpers.SecretLength];
+        _random.NextBytes(secret);
+        using (var stream = _resource.UserData.Open(DeviceKeyPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            stream.Write(secret);
+        }
+
+        return secret;
+    }
+
+    private byte[]? TryReadSecret()
+    {
+        try
+        {
+            using var stream = _resource.UserData.Open(DeviceKeyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var memory = new MemoryStream();
+            stream.CopyTo(memory);
+            var secret = memory.ToArray();
+            return secret.Length == DeviceKeyProofHelpers.SecretLength ? secret : null;
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+}

--- a/Content.Server/Administration/Managers/BanManager.cs
+++ b/Content.Server/Administration/Managers/BanManager.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Server._RuMC14.DeviceKey;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
 using Content.Server.GameTicking;
@@ -209,12 +210,23 @@ public sealed partial class BanManager : IBanManager, IPostInjectInit
 
     private bool BanMatchesPlayer(ICommonSession player, ServerBanDef ban)
     {
+        var hwId = player.Channel.UserData.HWId.Length == 0
+            ? (ImmutableArray<byte>?) null
+            : player.Channel.UserData.HWId;
+        var modernHwIds = player.Channel.UserData.ModernHWIds;
+
+        if (_systems.TryGetEntitySystem<DeviceKeyVerificationSystem>(out var deviceKey) &&
+            deviceKey.TryGetDeviceId(player, out var deviceId))
+        {
+            modernHwIds = [deviceId];
+        }
+
         var playerInfo = new BanMatcher.PlayerInfo
         {
             UserId = player.UserId,
             Address = player.Channel.RemoteEndPoint.Address,
-            HWId = player.Channel.UserData.HWId,
-            ModernHWIds = player.Channel.UserData.ModernHWIds,
+            HWId = hwId,
+            ModernHWIds = modernHwIds,
             // It's possible for the player to not have cached data loading yet due to coincidental timing.
             // If this is the case, we assume they have all flags to avoid false-positives.
             ExemptFlags = _cachedBanExemptions.GetValueOrDefault(player, ServerBanExemptFlags.All),

--- a/Content.Server/Administration/PlayerLocator.cs
+++ b/Content.Server/Administration/PlayerLocator.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Content.Server._RuMC14.DeviceKey;
 using Content.Server.Connection;
 using Content.Server.Database;
 using Content.Shared.Database;
@@ -76,9 +77,11 @@ namespace Content.Server.Administration
         [Dependency] private IConfigurationManager _configurationManager = default!;
         [Dependency] private IServerDbManager _db = default!;
         [Dependency] private ILogManager _logManager = default!;
+        [Dependency] private IEntitySystemManager _entitySystem = default!;
 
         private readonly HttpClient _httpClient = new();
         private ISawmill _sawmill = default!;
+        private DeviceKeyVerificationSystem? _deviceKey;
 
         public PlayerLocator()
         {
@@ -148,18 +151,27 @@ namespace Content.Server.Administration
             return new LocatedPlayerData(new NetUserId(responseData.UserId), null, null, responseData.UserName, null, []);
         }
 
-        private static LocatedPlayerData ReturnForSession(ICommonSession session)
+        private LocatedPlayerData ReturnForSession(ICommonSession session)
         {
             var userId = session.UserId;
             var address = session.Channel.RemoteEndPoint.Address;
+            var legacyHwId = session.Channel.UserData.HWId;
+            var modernHwIds = session.Channel.UserData.ModernHWIds;
             var hwId = session.Channel.UserData.GetModernHwid();
+
+            if (_deviceKey != null && _deviceKey.TryGetDeviceId(session, out var deviceId))
+            {
+                hwId = new ImmutableTypedHwid(deviceId, HwidType.Modern);
+                modernHwIds = [deviceId];
+            }
+
             return new LocatedPlayerData(
                 userId,
                 address,
                 hwId,
                 session.Name,
-                session.Channel.UserData.HWId,
-                session.Channel.UserData.ModernHWIds);
+                legacyHwId,
+                modernHwIds);
         }
 
         private static LocatedPlayerData ReturnForPlayerRecord(PlayerRecord record)
@@ -200,6 +212,7 @@ namespace Content.Server.Administration
         void IPostInjectInit.PostInject()
         {
             _sawmill = _logManager.GetSawmill("PlayerLocate");
+            _entitySystem.TryGetEntitySystem(out _deviceKey);
         }
     }
 }

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -750,6 +750,82 @@ namespace Content.Server.Database
             return flags ?? ServerBanExemptFlags.None;
         }
 
+        protected static async Task<(ImmutableArray<byte>? legacy, ImmutableArray<ImmutableArray<byte>> modern)> GetKnownHardwareIdsAsync(
+            DbGuard db,
+            NetUserId? userId,
+            ImmutableArray<byte>? currentLegacy,
+            ImmutableArray<ImmutableArray<byte>>? currentModern,
+            CancellationToken cancel = default)
+        {
+            var legacyIds = new List<ImmutableArray<byte>>();
+            var modernIds = new List<ImmutableArray<byte>>();
+
+            AddLegacyHwid(legacyIds, currentLegacy);
+            AddModernHwids(modernIds, currentModern);
+
+            if (userId != null)
+            {
+                var loggedHwids = await db.DbContext.ConnectionLog
+                    .AsNoTracking()
+                    .Where(log => log.UserId == userId.Value.UserId && log.HWId != null)
+                    .Select(log => log.HWId!)
+                    .ToListAsync(cancel);
+
+                foreach (var hwid in loggedHwids)
+                {
+                    switch (hwid.Type)
+                    {
+                        case HwidType.Legacy:
+                            AddLegacyHwid(legacyIds, hwid.Hwid.ToImmutableArray());
+                            break;
+                        case HwidType.Modern:
+                            AddModernHwid(modernIds, hwid.Hwid.ToImmutableArray());
+                            break;
+                    }
+                }
+            }
+
+            return (legacyIds.FirstOrDefault().IsDefaultOrEmpty ? null : legacyIds[0], modernIds.ToImmutableArray());
+        }
+
+        private static void AddLegacyHwid(List<ImmutableArray<byte>> hwids, ImmutableArray<byte>? hwid)
+        {
+            if (hwid is not { Length: > 0 } value)
+                return;
+
+            AddHwid(hwids, value);
+        }
+
+        private static void AddModernHwids(List<ImmutableArray<byte>> hwids, ImmutableArray<ImmutableArray<byte>>? modernHwids)
+        {
+            if (modernHwids == null)
+                return;
+
+            foreach (var hwid in modernHwids)
+            {
+                AddModernHwid(hwids, hwid);
+            }
+        }
+
+        private static void AddModernHwid(List<ImmutableArray<byte>> hwids, ImmutableArray<byte> hwid)
+        {
+            if (hwid.IsDefaultOrEmpty)
+                return;
+
+            AddHwid(hwids, hwid);
+        }
+
+        private static void AddHwid(List<ImmutableArray<byte>> hwids, ImmutableArray<byte> hwid)
+        {
+            foreach (var existing in hwids)
+            {
+                if (existing.AsSpan().SequenceEqual(hwid.AsSpan()))
+                    return;
+            }
+
+            hwids.Add(hwid);
+        }
+
         #endregion
 
         #region Role Bans

--- a/Content.Server/Database/ServerDbPostgres.cs
+++ b/Content.Server/Database/ServerDbPostgres.cs
@@ -77,16 +77,17 @@ namespace Content.Server.Database
             ImmutableArray<byte>? hwId,
             ImmutableArray<ImmutableArray<byte>>? modernHWIds)
         {
-            if (address == null && userId == null && hwId == null)
+            if (address == null && userId == null && hwId == null && modernHWIds is not { Length: > 0 })
             {
-                throw new ArgumentException("Address, userId, and hwId cannot all be null");
+                throw new ArgumentException("Address, userId, hwId, and modernHWIds cannot all be null or empty");
             }
 
             await using var db = await GetDbImpl();
 
             var exempt = await GetBanExemptionCore(db, userId);
             var newPlayer = userId == null || !await PlayerRecordExists(db, userId.Value);
-            var query = MakeBanLookupQuery(address, userId, hwId, modernHWIds, db, includeUnbanned: false, exempt, newPlayer)
+            var knownHwids = await GetKnownHardwareIdsAsync(db, userId, hwId, modernHWIds);
+            var query = MakeBanLookupQuery(address, userId, knownHwids.legacy, knownHwids.modern, db, includeUnbanned: false, exempt, newPlayer)
                 .OrderByDescending(b => b.BanTime);
 
             var ban = await query.FirstOrDefaultAsync();
@@ -100,16 +101,17 @@ namespace Content.Server.Database
             ImmutableArray<ImmutableArray<byte>>? modernHWIds,
             bool includeUnbanned)
         {
-            if (address == null && userId == null && hwId == null)
+            if (address == null && userId == null && hwId == null && modernHWIds is not { Length: > 0 })
             {
-                throw new ArgumentException("Address, userId, and hwId cannot all be null");
+                throw new ArgumentException("Address, userId, hwId, and modernHWIds cannot all be null or empty");
             }
 
             await using var db = await GetDbImpl();
 
             var exempt = await GetBanExemptionCore(db, userId);
             var newPlayer = !await db.PgDbContext.Player.AnyAsync(p => p.UserId == userId);
-            var query = MakeBanLookupQuery(address, userId, hwId, modernHWIds, db, includeUnbanned, exempt, newPlayer);
+            var knownHwids = await GetKnownHardwareIdsAsync(db, userId, hwId, modernHWIds);
+            var query = MakeBanLookupQuery(address, userId, knownHwids.legacy, knownHwids.modern, db, includeUnbanned, exempt, newPlayer);
 
             var queryBans = await query.ToArrayAsync();
             var bans = new List<ServerBanDef>(queryBans.Length);
@@ -137,7 +139,7 @@ namespace Content.Server.Database
             ServerBanExemptFlags? exemptFlags,
             bool newPlayer)
         {
-            DebugTools.Assert(!(address == null && userId == null && hwId == null));
+            DebugTools.Assert(!(address == null && userId == null && hwId == null && modernHWIds is not { Length: > 0 }));
 
             var query = MakeBanLookupQualityShared<ServerBan, ServerUnban>(
                 userId,
@@ -334,14 +336,15 @@ namespace Content.Server.Database
             ImmutableArray<ImmutableArray<byte>>? modernHWIds,
             bool includeUnbanned)
         {
-            if (address == null && userId == null && hwId == null)
+            if (address == null && userId == null && hwId == null && modernHWIds is not { Length: > 0 })
             {
-                throw new ArgumentException("Address, userId, and hwId cannot all be null");
+                throw new ArgumentException("Address, userId, hwId, and modernHWIds cannot all be null or empty");
             }
 
             await using var db = await GetDbImpl();
 
-            var query = MakeRoleBanLookupQuery(address, userId, hwId, modernHWIds, db, includeUnbanned)
+            var knownHwids = await GetKnownHardwareIdsAsync(db, userId, hwId, modernHWIds);
+            var query = MakeRoleBanLookupQuery(address, userId, knownHwids.legacy, knownHwids.modern, db, includeUnbanned)
                 .OrderByDescending(b => b.BanTime);
 
             return await QueryRoleBans(query);

--- a/Content.Server/Database/ServerDbSqlite.cs
+++ b/Content.Server/Database/ServerDbSqlite.cs
@@ -112,6 +112,7 @@ namespace Content.Server.Database
             var exempt = await GetBanExemptionCore(db, userId);
 
             var newPlayer = !await db.SqliteDbContext.Player.AnyAsync(p => p.UserId == userId);
+            var knownHwids = await GetKnownHardwareIdsAsync(db, userId, hwId, modernHWIds);
 
             // SQLite can't do the net masking stuff we need to match IP address ranges.
             // So just pull down the whole list into memory.
@@ -122,8 +123,8 @@ namespace Content.Server.Database
                 Address = address,
                 UserId = userId,
                 ExemptFlags = exempt ?? default,
-                HWId = hwId,
-                ModernHWIds = modernHWIds,
+                HWId = knownHwids.legacy,
+                ModernHWIds = knownHwids.modern,
                 IsNewPlayer = newPlayer,
             };
 
@@ -214,13 +215,14 @@ namespace Content.Server.Database
             bool includeUnbanned)
         {
             await using var db = await GetDbImpl();
+            var knownHwids = await GetKnownHardwareIdsAsync(db, userId, hwId, modernHWIds);
 
             // SQLite can't do the net masking stuff we need to match IP address ranges.
             // So just pull down the whole list into memory.
             var queryBans = await GetAllRoleBans(db.SqliteDbContext, includeUnbanned);
 
             return queryBans
-                .Where(b => RoleBanMatches(b, address, userId, hwId, modernHWIds))
+                .Where(b => RoleBanMatches(b, address, userId, knownHwids.legacy, knownHwids.modern))
                 .Select(ConvertRoleBan)
                 .ToList()!;
         }

--- a/Content.Server/_RuMC14/DeviceKey/DeviceKeyVerificationSystem.cs
+++ b/Content.Server/_RuMC14/DeviceKey/DeviceKeyVerificationSystem.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Content.Server.Database;
+using Content.Shared._RuMC14.DeviceKey;
+using Content.Shared.Database;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.Localization;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._RuMC14.DeviceKey;
+
+public sealed partial class DeviceKeyVerificationSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IServerDbManager _db = default!;
+    [Dependency] private ServerDbEntryManager _serverDbEntry = default!;
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private ILocalizationManager _loc = default!;
+    [Dependency] private ISharedPlayerManager _player = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    private readonly Dictionary<ICommonSession, PendingChallenge> _pending = new();
+    private readonly Dictionary<ICommonSession, ImmutableArray<byte>> _verifiedDeviceIds = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<DeviceKeyProofEvent>(OnDeviceKeyProof);
+        _player.PlayerStatusChanged += OnPlayerStatusChanged;
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _player.PlayerStatusChanged -= OnPlayerStatusChanged;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        foreach (var (session, pending) in _pending.ToArray())
+        {
+            if (now < pending.ExpiresAt)
+                continue;
+
+            _pending.Remove(session);
+            session.Channel.Disconnect("Device key verification timed out.");
+        }
+    }
+
+    public bool TryGetDeviceId(ICommonSession session, out ImmutableArray<byte> deviceId)
+    {
+        return _verifiedDeviceIds.TryGetValue(session, out deviceId);
+    }
+
+    private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs args)
+    {
+        if (args.NewStatus == SessionStatus.Disconnected)
+        {
+            _pending.Remove(args.Session);
+            _verifiedDeviceIds.Remove(args.Session);
+            return;
+        }
+
+        if (args.NewStatus != SessionStatus.Connected || args.OldStatus != SessionStatus.Connecting)
+            return;
+
+        var challenge = new byte[DeviceKeyProofHelpers.ChallengeLength];
+        _random.NextBytes(challenge);
+        _pending[args.Session] = new PendingChallenge(
+            challenge.ToImmutableArray(),
+            _timing.CurTime + TimeSpan.FromSeconds(DeviceKeyProofHelpers.ChallengeTimeoutSeconds));
+
+        RaiseNetworkEvent(new DeviceKeyChallengeEvent(challenge), args.Session);
+    }
+
+    private async void OnDeviceKeyProof(DeviceKeyProofEvent msg, EntitySessionEventArgs args)
+    {
+        var session = args.SenderSession;
+        if (!_pending.TryGetValue(session, out var pending))
+        {
+            session.Channel.Disconnect("Unexpected device key proof.");
+            return;
+        }
+
+        if (!BytesEqual(pending.Challenge, msg.Challenge) ||
+            !VerifyDeviceKeyProof(session.UserId.UserId, msg.Challenge, msg.DeviceId, msg.Secret, msg.Proof))
+        {
+            _pending.Remove(session);
+            session.Channel.Disconnect("Device key proof is invalid.");
+            return;
+        }
+
+        _pending.Remove(session);
+
+        var deviceId = msg.DeviceId.ToImmutableArray();
+        _verifiedDeviceIds[session] = deviceId;
+
+        var modernDeviceHwid = new ImmutableTypedHwid(deviceId, HwidType.Modern);
+        var address = session.Channel.RemoteEndPoint.Address;
+        var serverId = (await _serverDbEntry.ServerEntity).Id;
+        var bans = await _db.GetServerBansAsync(address, session.UserId, null, [deviceId], includeUnbanned: false);
+
+        if (bans.Count > 0)
+        {
+            var firstBan = bans[0];
+            var connectionId = await _db.AddConnectionLogAsync(
+                session.UserId,
+                session.Name,
+                address,
+                modernDeviceHwid,
+                session.Channel.UserData.Trust,
+                ConnectionDenyReason.Ban,
+                serverId);
+
+            await _db.AddServerBanHitsAsync(connectionId, bans);
+            session.Channel.Disconnect(firstBan.FormatBanMessage(_cfg, _loc));
+            return;
+        }
+
+        await _db.AddConnectionLogAsync(
+            session.UserId,
+            session.Name,
+            address,
+            modernDeviceHwid,
+            session.Channel.UserData.Trust,
+            null,
+            serverId);
+
+        await _db.UpdatePlayerRecordAsync(session.UserId, session.Name, address, modernDeviceHwid);
+    }
+
+    private static bool VerifyDeviceKeyProof(
+        Guid userId,
+        byte[] challenge,
+        byte[] deviceId,
+        byte[] secret,
+        byte[] proof)
+    {
+        if (deviceId.Length != DeviceKeyProofHelpers.DeviceIdLength ||
+            secret.Length != DeviceKeyProofHelpers.SecretLength ||
+            proof.Length != DeviceKeyProofHelpers.ProofLength)
+        {
+            return false;
+        }
+
+        var expectedDeviceId = DeviceKeyProofHelpers.GetDeviceId(secret);
+        if (!BytesEqual(deviceId, expectedDeviceId))
+            return false;
+
+        var expectedProof = DeviceKeyProofHelpers.MakeProof(secret, challenge, userId);
+        return BytesEqual(proof, expectedProof);
+    }
+
+    private static bool BytesEqual(ImmutableArray<byte> left, byte[] right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (left[i] != right[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool BytesEqual(byte[] left, byte[] right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (var i = 0; i < left.Length; i++)
+        {
+            if (left[i] != right[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    private readonly record struct PendingChallenge(ImmutableArray<byte> Challenge, TimeSpan ExpiresAt);
+}

--- a/Content.Shared/_RuMC14/DeviceKey/DeviceKeyMessages.cs
+++ b/Content.Shared/_RuMC14/DeviceKey/DeviceKeyMessages.cs
@@ -1,0 +1,123 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RuMC14.DeviceKey;
+
+[Serializable, NetSerializable]
+public sealed class DeviceKeyChallengeEvent : EntityEventArgs
+{
+    public byte[] Challenge { get; }
+
+    public DeviceKeyChallengeEvent(byte[] challenge)
+    {
+        Challenge = challenge;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class DeviceKeyProofEvent : EntityEventArgs
+{
+    public byte[] Challenge { get; }
+    public byte[] DeviceId { get; }
+    public byte[] Secret { get; }
+    public byte[] Proof { get; }
+
+    public DeviceKeyProofEvent(byte[] challenge, byte[] deviceId, byte[] secret, byte[] proof)
+    {
+        Challenge = challenge;
+        DeviceId = deviceId;
+        Secret = secret;
+        Proof = proof;
+    }
+}
+
+public static class DeviceKeyProofHelpers
+{
+    public const int ChallengeLength = 32;
+    public const int SecretLength = 32;
+    public const int DeviceIdLength = 32;
+    public const int ProofLength = 32;
+    public const int ChallengeTimeoutSeconds = 15;
+
+    public static byte[] GetDeviceId(byte[] secret)
+    {
+        var state = CreateHashState(0x44564944u);
+        UpdateAscii(state, "RUSSIANCM_DEVICE_ID_V1");
+        UpdateBytes(state, secret);
+        return FinishHash(state);
+    }
+
+    public static byte[] MakeProof(byte[] secret, byte[] challenge, Guid userId)
+    {
+        var state = CreateHashState(0x50524f46u);
+        UpdateAscii(state, "RUSSIANCM_DEVICE_PROOF_V1");
+        UpdateBytes(state, secret);
+        UpdateBytes(state, challenge);
+        UpdateBytes(state, userId.ToByteArray());
+        return FinishHash(state);
+    }
+
+    private static uint[] CreateHashState(uint seed)
+    {
+        var state = new uint[8];
+        state[0] = 0x811c9dc5u ^ seed;
+        state[1] = 0x01000193u + seed;
+        state[2] = 0x9e3779b9u ^ seed;
+        state[3] = 0x85ebca6bu + seed;
+        state[4] = 0xc2b2ae35u ^ seed;
+        state[5] = 0x27d4eb2fu + seed;
+        state[6] = 0x165667b1u ^ seed;
+        state[7] = 0xd3a2646cu + seed;
+        return state;
+    }
+
+    private static void UpdateAscii(uint[] state, string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+            UpdateByte(state, (byte) value[i]);
+    }
+
+    private static void UpdateBytes(uint[] state, byte[] value)
+    {
+        UpdateByte(state, (byte) value.Length);
+        UpdateByte(state, (byte) (value.Length >> 8));
+
+        for (var i = 0; i < value.Length; i++)
+            UpdateByte(state, value[i]);
+    }
+
+    private static void UpdateByte(uint[] state, byte value)
+    {
+        for (var i = 0; i < state.Length; i++)
+        {
+            var mixed = state[i] ^ (uint) (value + i * 17);
+            mixed *= 16777619u;
+            mixed ^= mixed >> 13;
+            mixed = (mixed << 7) | (mixed >> 25);
+            state[i] = mixed + 0x9e3779b9u + (uint) i;
+        }
+    }
+
+    private static byte[] FinishHash(uint[] state)
+    {
+        var result = new byte[32];
+
+        for (var round = 0; round < 16; round++)
+        {
+            for (var i = 0; i < state.Length; i++)
+                UpdateByte(state, (byte) (round * 31 + i));
+        }
+
+        for (var i = 0; i < state.Length; i++)
+            WriteUInt32(result, i * 4, state[i]);
+
+        return result;
+    }
+
+    private static void WriteUInt32(byte[] data, int offset, uint value)
+    {
+        data[offset] = (byte) value;
+        data[offset + 1] = (byte) (value >> 8);
+        data[offset + 2] = (byte) (value >> 16);
+        data[offset + 3] = (byte) (value >> 24);
+    }
+}


### PR DESCRIPTION
## What changed

- Added a content-level device token challenge/proof flow without modifying RobustToolbox.
- The client stores a persistent device secret in user data and responds to a server nonce.
- The server verifies the response, treats the secret hash as a modern HWID, and checks existing server bans against it.
- Player lookup and ban matching now prefer the verified content device id for online players.
- Ban lookup also considers historical HWIDs from connection logs for the same user.

## Why

Players could bypass bans by changing account, IP, and spoofable HWID values. This raises the bar by requiring possession of a persistent local device token while keeping the implementation in content code instead of the engine submodule.

## Validation

- `dotnet build Content.Client\Content.Client.csproj --no-restore`
- `dotnet build Content.Server\Content.Server.csproj --no-restore`

Both builds completed successfully. Existing warnings remain.

## Notes

Robust content sandbox blocks direct use of `System.Security.Cryptography` and direct file APIs in content assemblies, so this PR uses a sandbox-safe token proof and the existing user-data VFS. This is weaker than engine-level public/private key attestation, but avoids RobustToolbox changes.